### PR TITLE
use audio files from p5.js website assets folder

### DIFF
--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -18,7 +18,7 @@ import { Context as ToneContext } from "tone/build/esm/core/context/Context.js";
  *   
  * function preload() {
  *   //replace this sound with something local with rights to distribute
- *   sound = loadSound('assets/Damscray_DancingTiger.mp3');
+ *   sound = loadSound('/assets/Damscray_DancingTiger.mp3');
  * }
  * 
  * function setup() {

--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -18,7 +18,7 @@ import { Context as ToneContext } from "tone/build/esm/core/context/Context.js";
  *   
  * function preload() {
  *   //replace this sound with something local with rights to distribute
- *   sound = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+ *   sound = loadSound('assets/Damscray_DancingTiger.mp3');
  * }
  * 
  * function setup() {

--- a/src/Panner.js
+++ b/src/Panner.js
@@ -18,7 +18,7 @@ import { clamp } from './Utils';
  * let panner, lfo, soundfile, cnv;
  * 
  * function preload() {
- *   soundfile = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+ *   soundfile = loadSound('assets/beat.mp3');
  * }
  * 
  * function setup() {

--- a/src/Panner.js
+++ b/src/Panner.js
@@ -18,7 +18,7 @@ import { clamp } from './Utils';
  * let panner, lfo, soundfile, cnv;
  * 
  * function preload() {
- *   soundfile = loadSound('assets/beat.mp3');
+ *   soundfile = loadSound('/assets/beat.mp3');
  * }
  * 
  * function setup() {

--- a/src/Panner3D.js
+++ b/src/Panner3D.js
@@ -28,8 +28,8 @@ import { Panner3D as TonePanner3D} from "tone/build/esm/component/channel/Panner
  * let vZ;
  * 
  * function preload() {
- *   soundSource = loadSound('assets/beat.mp3');
- *   font = loadFont('assets/SourceSansPro-Regular.otf');
+ *   soundSource = loadSound('/assets/beat.mp3');
+ *   font = loadFont('/assets/SourceSansPro-Regular.otf');
  * }
  * 
  * function setup() {

--- a/src/Panner3D.js
+++ b/src/Panner3D.js
@@ -28,8 +28,8 @@ import { Panner3D as TonePanner3D} from "tone/build/esm/component/channel/Panner
  * let vZ;
  * 
  * function preload() {
- *   soundSource = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
- *   font = loadFont('https://cdn.glitch.global/3db712b6-c53c-49eb-a8ea-83c7a363871d/Canterbury.ttf?v=1715211442728');
+ *   soundSource = loadSound('assets/beat.mp3');
+ *   font = loadFont('assets/SourceSansPro-Regular.otf');
  * }
  * 
  * function setup() {

--- a/src/PitshShifter.js
+++ b/src/PitshShifter.js
@@ -17,7 +17,7 @@ import { PitchShift as TonePitchShift } from "tone/build/esm/effect/PitchShift.j
  *  let cnv, soundFile, pitchShifter;
  *  
  * function preload() {
- *   soundFile = loadSound('assets/gtrSample.mp3');
+ *   soundFile = loadSound('assets/beatbox.mp3');
  * }
  *  
  * function setup() {

--- a/src/PitshShifter.js
+++ b/src/PitshShifter.js
@@ -17,7 +17,7 @@ import { PitchShift as TonePitchShift } from "tone/build/esm/effect/PitchShift.j
  *  let cnv, soundFile, pitchShifter;
  *  
  * function preload() {
- *   soundFile = loadSound('assets/beatbox.mp3');
+ *   soundFile = loadSound('/assets/beatbox.mp3');
  * }
  *  
  * function setup() {

--- a/src/SoundFile.js
+++ b/src/SoundFile.js
@@ -31,7 +31,7 @@ import { Player as TonePlayer } from "tone/build/esm/source/buffer/Player.js";
  *  <div><code>
  *  let mySound;
  *  function preload() {
- *    mySound = loadSound('assets/doorbell.mp3');
+ *    mySound = loadSound('/assets/doorbell.mp3');
  *  }
  *
  *  function setup() {
@@ -70,7 +70,7 @@ function loadSound (path) {
  * function preload() {
  *   //replace this sound with something local with rights to distribute
  *   //need to fix local asset loading first though :) 
- *   sound = loadSound('assets/doorbell.mp3');
+ *   sound = loadSound('/assets/doorbell.mp3');
  * }
  * 
  * function setup() {
@@ -155,7 +155,7 @@ class SoundFile {
    * let player;
    *
    * function preload() {
-   *   player = loadSound('assets/Damscray_DancingTiger.mp3');
+   *   player = loadSound('/assets/Damscray_DancingTiger.mp3');
    * }
    * 
    * function setup() {
@@ -241,7 +241,7 @@ class SoundFile {
    * let soundSource, cnv, btn;
    *
    * function preload() {
-   *   soundSource = loadSound('assets/Damscray_-_Dancing_Tiger_01.mp3');
+   *   soundSource = loadSound('/assets/Damscray_-_Dancing_Tiger_01.mp3');
    * }
    * 
    * function setup() {
@@ -266,7 +266,7 @@ class SoundFile {
    * function setNewPath() {
    *   background(220);
    *   text('a new sound was loaded', 0, 20, 100);
-   *   soundSource.setPath('assets/Damscray_-_Dancing_Tiger_02.mp3', playSound); 
+   *   soundSource.setPath('/assets/Damscray_-_Dancing_Tiger_02.mp3', playSound); 
    * }
    * </code>
    * </div>
@@ -356,7 +356,7 @@ class SoundFile {
    * let player;
    *
    * function preload() {
-   *   player = loadSound('assets/lucky_dragons_-_power_melody.mp3');
+   *   player = loadSound('/assets/lucky_dragons_-_power_melody.mp3');
    * }
    * 
    * function setup() {
@@ -399,7 +399,7 @@ class SoundFile {
    * let player;
    *
    * function preload() {
-   *   player = loadSound('assets/lucky_dragons_-_power_melody.mp3');
+   *   player = loadSound('/assets/lucky_dragons_-_power_melody.mp3');
    * }
    * 
    * function setup() {

--- a/src/SoundFile.js
+++ b/src/SoundFile.js
@@ -31,7 +31,7 @@ import { Player as TonePlayer } from "tone/build/esm/source/buffer/Player.js";
  *  <div><code>
  *  let mySound;
  *  function preload() {
- *    mySound = loadSound('assets/doorbell');
+ *    mySound = loadSound('assets/doorbell.mp3');
  *  }
  *
  *  function setup() {
@@ -70,7 +70,7 @@ function loadSound (path) {
  * function preload() {
  *   //replace this sound with something local with rights to distribute
  *   //need to fix local asset loading first though :) 
- *   sound = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+ *   sound = loadSound('assets/doorbell.mp3');
  * }
  * 
  * function setup() {
@@ -155,7 +155,7 @@ class SoundFile {
    * let player;
    *
    * function preload() {
-   *   player = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+   *   player = loadSound('assets/Damscray_DancingTiger.mp3');
    * }
    * 
    * function setup() {
@@ -241,7 +241,7 @@ class SoundFile {
    * let soundSource, cnv, btn;
    *
    * function preload() {
-   *   soundSource = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+   *   soundSource = loadSound('assets/Damscray_-_Dancing_Tiger_01.mp3');
    * }
    * 
    * function setup() {
@@ -266,7 +266,7 @@ class SoundFile {
    * function setNewPath() {
    *   background(220);
    *   text('a new sound was loaded', 0, 20, 100);
-   *   soundSource.setPath('https://tonejs.github.io/audio/berklee/gong_2.mp3', playSound); 
+   *   soundSource.setPath('assets/Damscray_-_Dancing_Tiger_02.mp3', playSound); 
    * }
    * </code>
    * </div>
@@ -356,7 +356,7 @@ class SoundFile {
    * let player;
    *
    * function preload() {
-   *   player = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+   *   player = loadSound('assets/lucky_dragons_-_power_melody.mp3');
    * }
    * 
    * function setup() {
@@ -399,7 +399,7 @@ class SoundFile {
    * let player;
    *
    * function preload() {
-   *   player = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+   *   player = loadSound('assets/lucky_dragons_-_power_melody.mp3');
    * }
    * 
    * function setup() {


### PR DESCRIPTION
current main branch uses audio assets from [tone](https://tonejs.github.io/), these diffs update the audio files to use the old assets in the p5.js assets folder - would be great to update these sounds to new ones very soon, maybe keep a few of the old ones. 