### PR TITLE
Fix examples 002+006 and clean up variable declarations in all examples

### DIFF
--- a/examples/002-Amplitude-VisualizingLoudness/sketch.js
+++ b/examples/002-Amplitude-VisualizingLoudness/sketch.js
@@ -3,7 +3,8 @@ let amp;
 
 async function setup() {
   sound = await loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
-  createCanvas(400, 400);
+  let cnv = createCanvas(400, 400);
+  cnv.mousePressed(startSound);
   textAlign(CENTER);
   fill(255);
 
@@ -12,7 +13,7 @@ async function setup() {
   describe('The color of the background changes based on the amplitude of the sound.');
 }
  
-function mousePressed() {
+function startSound() {
   sound.play();
 }
  

--- a/examples/002-Amplitude-VisualizingLoudness/sketch.js
+++ b/examples/002-Amplitude-VisualizingLoudness/sketch.js
@@ -1,12 +1,14 @@
+let sound;
+let amp;
+
 async function setup() {
-  sound = loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
+  sound = await loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
   createCanvas(400, 400);
   textAlign(CENTER);
   fill(255);
 
   amp = new p5.Amplitude();
   sound.connect(amp);
-
   describe('The color of the background changes based on the amplitude of the sound.');
 }
  

--- a/examples/003-Microphone-Effects/sketch.js
+++ b/examples/003-Microphone-Effects/sketch.js
@@ -37,6 +37,6 @@ function startMic() {
 function draw() {
   text('click to open mic, watch out for feedback', 0 , 200, 400);
   text('move the mouse to change the delay time', 0 , 220, 400);
-  d = map(mouseX, 0, width, 0.1, 0.5);
+  let d = map(mouseX, 0, width, 0.1, 0.5);
   delay.delayTime(d);
 }

--- a/examples/004-OscillatorAmplitudeLFOmodulation/sketch.js
+++ b/examples/004-OscillatorAmplitudeLFOmodulation/sketch.js
@@ -1,11 +1,10 @@
 let osc, lfo;
-let cnv;
 
 function setup() {
   describe(
     "a sketch that demonstrates amplitude modulation with an LFO and sine tone"
   );
-  cnv = createCanvas(100, 100);
+  let cnv = createCanvas(100, 100);
   cnv.mousePressed(startSound);
   textAlign(CENTER);
   textWrap(WORD);

--- a/examples/005-Oscillator-Reverb/sketch.js
+++ b/examples/005-Oscillator-Reverb/sketch.js
@@ -1,4 +1,4 @@
-let osc, reverb;
+let osc;
 let playing = false;
 
 function setup() {
@@ -6,7 +6,7 @@ function setup() {
   background(220);
   cnv.mousePressed(playSound);
   osc = new p5.Oscillator();
-  reverb = new p5.Reverb();
+  let reverb = new p5.Reverb();
   osc.disconnect();
   osc.connect(reverb);
   textAlign(CENTER);

--- a/examples/006-DelayTime-Envelope_b/sketch.js
+++ b/examples/006-DelayTime-Envelope_b/sketch.js
@@ -1,5 +1,5 @@
-let osc, osc2, os3, delay, env, ampy, started = false;
-let lfo1, lfo2, lfo3;
+let  ampy, delay, env, lfo1, lfo2, lfo3, osc, osc2, osc3;
+let started = false;
 function setup() {
   let cnv = createCanvas(400, 400);
   background(220);

--- a/examples/006-EnvelopeAndfilter/sketch.js
+++ b/examples/006-EnvelopeAndfilter/sketch.js
@@ -1,5 +1,3 @@
-let osc;
-let env;
 let noiseGen;
 let lowPass;
 

--- a/examples/006-EnvelopeAndfilter/sketch.js
+++ b/examples/006-EnvelopeAndfilter/sketch.js
@@ -1,4 +1,7 @@
-let osc, env;
+let osc;
+let env;
+let noiseGen;
+let lowPass;
 
 function setup() {
   let cnv = createCanvas(100, 100);
@@ -14,27 +17,25 @@ function setup() {
   lowPass = new p5.Biquad();
   lowPass.res = 79;
   
-  noise = new p5.Noise('white');
-  noise.disconnect();
-  noise.connect(lowPass)
+  noiseGen = new p5.Noise('white');
+  noiseGen.disconnect();
+  noiseGen.connect(lowPass)
 }
 
 function draw(){
-  cutoff = map(mouseY, height, 0, 300, 20000)
+  let cutoff = map(mouseY, height, 0, 300, 20000)
   //pitch = map(mouseX, 0, width, 90, 2000)
   lowPass.freq(cutoff) 
 }
 
 function playSound() {
-  noise.start()
+  noiseGen.start()
   background(0, 255, 255);
   text('release to stop noise', 0, 40, 100);
-  
 }
 
 function stopSound() {
   background(220);
-  noise.stop()
+  noiseGen.stop()
   text('tap to start noise', 0, 40, 100);
-  
 }

--- a/examples/008-FFT-WaveForm-Visualize/sketch.js
+++ b/examples/008-FFT-WaveForm-Visualize/sketch.js
@@ -1,4 +1,4 @@
-let osc;
+let fft, osc;
 
 
 function setup(){

--- a/examples/008_b-FFT-WaveForm-VisualizeSoundFile/sketch.js
+++ b/examples/008_b-FFT-WaveForm-VisualizeSoundFile/sketch.js
@@ -1,4 +1,5 @@
-let verb, filter;
+let filter;
+let fft;
 let soundFile;
 
 async function setup(){
@@ -7,7 +8,7 @@ async function setup(){
   cnv.mouseClicked(togglePlay);
   filter = new p5.Biquad(800, 'lowpass');
   filter.res(18);
-  verb = new p5.Reverb(0.850);
+  let verb = new p5.Reverb(0.850);
   fft = new p5.FFT(32);
   soundFile.disconnect();
   soundFile.amp(2.0)

--- a/examples/009-NoiseTypes/sketch.js
+++ b/examples/009-NoiseTypes/sketch.js
@@ -1,23 +1,22 @@
-let noise, env, cnv;
+let noiseGen, env;
 let types = ['white', 'pink', 'brown'];
 let noiseType = 'brown';
  
 function setup() {
-  cnv = createCanvas(100, 100);
+  let cnv = createCanvas(100, 100);
   textAlign(CENTER);
   cnv.mousePressed(startSound);
-  noise = new p5.Noise(noiseType);
+  noiseGen = new p5.Noise(noiseType);
   env = new p5.Envelope(0.01, 0.1, 0.45, 0.5);
-  noise.disconnect();
-  noise.connect(env);
-  
+  noiseGen.disconnect();
+  noiseGen.connect(env);
 }
  
 function startSound() {
   noiseType = random(types);
-  noise.type(noiseType);
-  noise.amp(0.2);
-  noise.start();
+  noiseGen.type(noiseType);
+  noiseGen.amp(0.2);
+  noiseGen.start();
   env.play();
 }
  

--- a/examples/010-PitchShifterOnSampleEnded/sketch.js
+++ b/examples/010-PitchShifterOnSampleEnded/sketch.js
@@ -1,9 +1,9 @@
-let cnv, soundFile, pitchShifter;
+let soundFile, pitchShifter;
 let shifts = [-1, 1, 2, -2, 8, 4];
  
 async function setup() {
   describe('a sketch that loops a sample of a guitar note, each time the note is played the pitch is shifted');
-  cnv = createCanvas(100, 100);
+  let cnv = createCanvas(100, 100);
   soundFile = await loadSound('assets/gtrSample.mp3');
   cnv.mousePressed(startSound);
   background(220);

--- a/examples/011-ReverbDecayTime/sketch.js
+++ b/examples/011-ReverbDecayTime/sketch.js
@@ -1,4 +1,4 @@
-let noise, osc, env, reverb;
+let noiseGen, env, reverb;
 let randomTime = 0;
 
 function setup() {
@@ -6,11 +6,11 @@ function setup() {
   let cnv = createCanvas(100, 100);
   cnv.mousePressed(playSound);
   
-  noise = new p5.Noise();
+  noiseGen = new p5.Noise();
   env = new p5.Envelope(0, 0.1);
   reverb = new p5.Reverb();
-  noise.disconnect();
-  noise.connect(env);
+  noiseGen.disconnect();
+  noiseGen.connect(env);
   env.disconnect();
   env.connect(reverb);
   
@@ -19,7 +19,7 @@ function setup() {
 }
 
 function playSound() {
-  noise.start();
+  noiseGen.start();
   randomTime = random(0.1, 3);
   reverb.set(randomTime);
   env.play();

--- a/examples/012-SoundFileSetPath/sketch.js
+++ b/examples/012-SoundFileSetPath/sketch.js
@@ -1,10 +1,10 @@
 //this sketch demonstrates how to change the path of a sound file that was loaded in with loadSound()
-let soundSource, cnv, btn;
+let soundSource, btn;
 
 async function setup() {
   describe(
     "a sketch that says click to play sound. there is a button that says load sound. when you click the button, the path of the sound file player changes and the new sound plays.");
-  cnv = createCanvas(100, 100);
+  let cnv = createCanvas(100, 100);
   soundSource = await loadSound("https://tonejs.github.io/audio/berklee/gong_1.mp3");
   cnv.mousePressed(playSound);
   background(220);

--- a/examples/013-MultiSamplePlaybackWithAmplitudeAnalysis/sketch.js
+++ b/examples/013-MultiSamplePlaybackWithAmplitudeAnalysis/sketch.js
@@ -1,13 +1,9 @@
 //what if we want a beginning middle and end
 
 let samples = [];
-let delay;
 let started = false;
 let filter;
-let cnv;
-let button;
 let ampy;
-let timer;
 
 let paths = [
   "assets/sample_0.mp3",
@@ -37,7 +33,7 @@ async function loadAllSounds() {
 }
 
 async function setup() {
-  cnv = createCanvas(400, 400);
+  let cnv = createCanvas(400, 400);
   await loadAllSounds();
   background(0, 0, 255);
   cnv.mousePressed(startSound);
@@ -47,7 +43,7 @@ async function setup() {
   //vary the frameRate to create variations in sample triggers
   //frameRate(10 + random(-4, 10));
   ampy = new p5.Amplitude();
-  delay = new p5.Delay();
+  let delay = new p5.Delay();
   delay.delayTime(0.256);
   delay.feedback(0.6);
   filter = new p5.Biquad();
@@ -83,8 +79,6 @@ function draw() {
     noStroke();
     circle(width/2, height/2, ampy.getLevel() * 250 + 130);
   }
-  
-  
 }
 
 function startSound() {

--- a/examples/014-3DSoundSource/sketch.js
+++ b/examples/014-3DSoundSource/sketch.js
@@ -1,7 +1,5 @@
 let radius = 10;
 let soundSource, spatializer;
-let font;
-let cnv;
 
 let x = 0;
 let y = 0;
@@ -15,7 +13,7 @@ async function setup() {
   describe(
     "A 3D shape with a sound source attached to it. The sound source is spatialized using the Panner3D class. Click to play the sound."
   );
-  cnv = createCanvas(100, 100, WEBGL);
+  let cnv = createCanvas(100, 100, WEBGL);
   soundSource = await loadSound("https://tonejs.github.io/audio/berklee/gong_1.mp3");
   cnv.mousePressed(playSound);
 

--- a/examples/015-SoundFile3DScale/sketch.js
+++ b/examples/015-SoundFile3DScale/sketch.js
@@ -1,6 +1,5 @@
 let player, measure;
 
-
 async function setup() {
   player = await loadSound('https://tonejs.github.io/audio/berklee/gong_1.mp3');
   describe('A sketch that pauses and resumes sound file playback.');
@@ -14,7 +13,7 @@ async function setup() {
 function draw() {
   background(220)
   orbitControl();
-  amplitude = measure.getLevel() * 1000;
+  let amplitude = measure.getLevel() * 1000;
   // Draw the box.
   let angle = createVector(1, 1, 0);
   rotate(1, angle);

--- a/examples/016-String-Synthesis/sketch.js
+++ b/examples/016-String-Synthesis/sketch.js
@@ -1,6 +1,6 @@
 ///kind of Karplus-Strong string synthesis using p5.sound.js
 
-let noise, lowPass, hiPass, delay, env, gain, damper, delay2, fft;
+let noiseGen, delay, env;
 
 let frequencies = [440.000, 880.000, 1760.000, 523.251, 1046.502, 587.330, 1174.659, 659.255, 1318.510, 783.991, 1567.982, 880.000, 1760.000];
 
@@ -10,15 +10,15 @@ function setup() {
   textAlign(CENTER);
   textSize(9);
   text('click to pluck', width/2, height/2);
-  noise = new p5.Noise('white');
+  noiseGen = new p5.Noise('white');
   env = new p5.Envelope(0);
-  lowPass = new p5.Biquad(2500, 'lowpass');
-  hiPass = new p5.Biquad(55, 'highpass');
+  let lowPass = new p5.Biquad(2500, 'lowpass');
+  let hiPass = new p5.Biquad(55, 'highpass');
   delay = new p5.Delay(0.0005, 0.9);
-  gain = new p5.Gain(0.5);
-  delay2 = new p5.Delay(0.1, 0.74);
-  noise.disconnect();
-  noise.connect(hiPass);
+  let gain = new p5.Gain(0.5);
+  let delay2 = new p5.Delay(0.1, 0.74);
+  noiseGen.disconnect();
+  noiseGen.connect(hiPass);
   hiPass.disconnect();
   hiPass.connect(env);
   env.disconnect();
@@ -39,7 +39,7 @@ function pluckStart() {
   text('release to trigger decay', width/2, height/2);
   let pitch = (1000 / random(frequencies)) * 0.001; 
   delay.delayTime(pitch, 0);  
-  noise.start();
+  noiseGen.start();
   env.triggerAttack();
 }
 

--- a/examples/016-String-Synthesis_b/sketch.js
+++ b/examples/016-String-Synthesis_b/sketch.js
@@ -2,7 +2,7 @@
 //TODO: implement damping
 //click and hold to simulate a string pluck, move the mouse to change filter resonance and cutoff. release mouse to trigger decay.
 
-let noise, lowPass, hiPass, delay, env, gain, damper, delay2, fft;
+let noiseGen, lowPass, delay, env, fft;
 
 let plucked = false;
 
@@ -15,16 +15,16 @@ function setup() {
   textSize(15);
   strokeWeight(.1);
   text('click to pluck', width/2, height/2);
-  noise = new p5.Noise('pink');
+  noiseGen = new p5.Noise('pink');
   env = new p5.Envelope(0);
   lowPass = new p5.Biquad(2500, 'lowpass');
-  hiPass = new p5.Biquad(55, 'highpass');
+  let hiPass = new p5.Biquad(55, 'highpass');
   delay = new p5.Delay(0.0005, 0.9);
-  gain = new p5.Gain(0.5);
-  delay2 = new p5.Delay(0.1, 0.74);
+  let gain = new p5.Gain(0.5);
+  let delay2 = new p5.Delay(0.1, 0.74);
   
-  noise.disconnect(); //disconnect from speakers
-  noise.connect(hiPass); //connects to the highpass filter
+  noiseGen.disconnect(); //disconnect from speakers
+  noiseGen.connect(hiPass); //connects to the highpass filter
   hiPass.disconnect(); 
   hiPass.connect(env);
   env.disconnect();
@@ -49,7 +49,7 @@ function pluckStart() {
   
   let pitch = (1000 / random(frequencies)) * 0.001; 
   delay.delayTime(pitch, 0);  
-  noise.start();
+  noiseGen.start();
   env.triggerAttack();
 }
 

--- a/examples/018-Oscillator-Delay/sketch.js
+++ b/examples/018-Oscillator-Delay/sketch.js
@@ -1,7 +1,6 @@
 //mixolydian
 let scale = [100, 112.5, 125, 133.3, 150, 166.6, 175, 200]
-let osc
-let del
+let osc;
 
 //this runs once 
 function setup() {
@@ -9,10 +8,10 @@ function setup() {
   background(240);
   osc = new p5.Oscillator()
   osc.amp(0.5);
-  del = new p5.Delay(0.250, 0.7)
+  let delay = new p5.Delay(0.250, 0.7)
   osc.setType('triangle')
   osc.disconnect();
-  osc.connect(del)
+  osc.connect(delay)
   
   osc.start()
   frameRate(1)

--- a/examples/p5-to-tone/sketch.js
+++ b/examples/p5-to-tone/sketch.js
@@ -26,8 +26,7 @@
 
 //physical modelling
 
-let synth, ctx
-
+let env, osc, synth;
 
 function setup() {
   createCanvas(400, 400);
@@ -40,19 +39,13 @@ function setup() {
   //connect the osc to envelope
   osc.connect(env)
   
-  ctx = getAudioContext()
+  let ctx = getAudioContext()
   
   Tone.setContext(ctx)
   
-  
   synth = new Tone.MembraneSynth();
 
-
-  
-  
-  
-  
-  rev = new p5.Reverb(3)
+  let rev = new p5.Reverb(3)
   
   env.disconnect()
   env.connect(rev)
@@ -63,7 +56,7 @@ function draw() {
 }
 
 function mousePressed() {
-  console.log('mousewas clicked')
+  console.log('mouse was clicked')
   //play osc and env
   osc.start();
   env.play();


### PR DESCRIPTION
1. fixed examples 002 and 006-EnvelopeAndfilter
* 002: was missing await for loadSound - my mistake during upgrade to p5v2.
* 006: An intended (undeclared) variable name `noise` was colliding with p5's global fn of same name.

2. Made a small sweep of examples to tidy the following: 
* Declare all variables (locally, if possible).
* Remove unused variables.
* use "noiseGen" var name instead of "noise", to avoid possible collision/confusion with p5's noise().
* move towards consistent common variable names (e.g. "reverb" over "verb", "delay" over "del")

### Testing status: 

These local examples now ALL reliably pass against chromium.
After #91 they all pass against firefox except examples/p5-to-tone.