### PR TITLE
docs: update remaining loadSound examples to use async/await

### DIFF
--- a/src/analysis/Amplitude.js
+++ b/src/analysis/Amplitude.js
@@ -19,17 +19,14 @@ import { p5soundNode } from "../core/p5soundNode.js";
  * <div>
  * <code>
  * let sound, amp, cnv;
- *   
- * function preload() {
- *   //replace this sound with something local with rights to distribute
- *   sound = loadSound('/assets/Damscray_DancingTiger.mp3');
- * }
- * 
- * function setup() {
+ *
+ * async function setup() {
  *   cnv = createCanvas(100, 100);
  *   cnv.mousePressed(playSound);
  *   textAlign(CENTER);
  *   fill(255);
+ *   //replace this sound with something local with rights to distribute
+ *   sound = await loadSound('/assets/Damscray_DancingTiger.mp3');
  *   amp = new p5.Amplitude();
  *   sound.connect(amp);
  * }

--- a/src/effects/Gain.js
+++ b/src/effects/Gain.js
@@ -16,15 +16,12 @@ import { p5soundNode } from "../core/p5soundNode.js";
  * <div>
  * <code>
  * let cnv, soundFile, osc, gain;
- * 
- * function preload() {
- *   soundFile = loadSound('assets/Damscray_DancingTiger.mp3');
- * }
- * 
- * function setup() {
+ *
+ * async function setup() {
  *   cnv = createCanvas(100, 100);
  *   cnv.mousePressed(playSound);
  *   background(220);
+ *   soundFile = await loadSound('assets/Damscray_DancingTiger.mp3');
  *   gain = new p5.Gain(0.74);
  *   osc = new p5.Oscillator();
  *   osc.amp(0.74);

--- a/src/effects/Panner.js
+++ b/src/effects/Panner.js
@@ -18,15 +18,12 @@
    * <div>
    * <code>
    * let panner, lfo, soundfile, cnv;
-   * 
-   * function preload() {
-   *   soundfile = loadSound('/assets/beat.mp3');
-   * }
-   * 
-   * function setup() {
+   *
+   * async function setup() {
    *   createCanvas(100, 100);
    *   describe("a sketch that pans a sound source to the left speaker channel")
    *   background(220);
+   *   soundfile = await loadSound('/assets/beat.mp3');
    *   panner = new p5.Panner(-1);
    *   soundfile.loop();
    *   soundfile.disconnect();
@@ -58,15 +55,12 @@
      * <div>
      * <code>
      * let panner, lfo, soundfile, cnv;
-     * 
-     * function preload() {
-     *   soundfile = loadSound('/assets/beat.mp3');
-     * }
-     * 
-     * function setup() {
+     *
+     * async function setup() {
      *   createCanvas(100, 100);
      *   describe("a sketch that pans a sound source between the left and right speaker channels");
      *   background(220);
+     *   soundfile = await loadSound('/assets/beat.mp3');
      *   panner = new p5.Panner();
      *   lfo = new p5.Oscillator(1);
      *   //disconnect lfo from speakers because we don't want to hear it!

--- a/src/effects/Panner3D.js
+++ b/src/effects/Panner3D.js
@@ -28,16 +28,13 @@ import { p5soundNode } from "../core/p5soundNode.js";
  * let vY;
  * let vZ;
  * 
- * function preload() {
- *   soundSource = loadSound('/assets/beat.mp3');
- *   font = loadFont('/assets/SourceSansPro-Regular.otf');
- * }
- * 
- * function setup() {
+ * async function setup() {
  *   describe(
  *     'A 3D shape with a sound source attached to it. The sound source is spatialized using the Panner3D class. Click to play the sound.'
  *   );
  *   cnv = createCanvas(100, 100, WEBGL);
+ *   soundSource = await loadSound('/assets/beat.mp3');
+ *   font = await loadFont('/assets/SourceSansPro-Regular.otf');
  *   cnv.mousePressed(playSound);
  * 
  *   camera(0, 0, 0, 0, 0, 1);


### PR DESCRIPTION
## Summary
- Panner.js, Panner3D.js, Amplitude.js, and Gain.js still documented loadSound() being called from preload(), which is stale now that loadSound() uses an async/await pattern (see 86c3bcf).
- Updated all four to use `async function setup()` + `await loadSound(...)`, consistent with SoundFile.js, Reverb.js, and Delay.js.

Refs #106

## Test plan
- [ ] Verify JSDoc examples render correctly on the docs site
- [ ] Confirm no other files reference loadSound() inside preload()
